### PR TITLE
#14 Add reference on constructor

### DIFF
--- a/homer/lib/homer/Utilities/contructor.ex
+++ b/homer/lib/homer/Utilities/contructor.ex
@@ -1,0 +1,16 @@
+defmodule Homer.Utilities.Constructor do
+  @doc """
+    Return if a error occured on construct.
+
+    ## Examples
+
+      iex> error_on_create({:ok, %{id: 1}})
+           false
+
+      iex> error_on_create({:error, %{id: 1}})
+           true
+  """
+  def error_on_create({:ok, _}), do: false
+  def error_on_create(_), do: true
+
+end

--- a/homer/lib/homer/Utilities/contructor.ex
+++ b/homer/lib/homer/Utilities/contructor.ex
@@ -13,4 +13,18 @@ defmodule Homer.Utilities.Constructor do
   def error_on_create({:ok, _}), do: false
   def error_on_create(_), do: true
 
+
+  def same_fk(elements, attrs, key_id) when is_list(key_id) do
+    Enum.each(key_id,
+      fn key ->
+        case Map.has_key?(elements, key) and  Map.has_key?(attrs, key) do
+          true ->
+            Map.get(elements, key) == Map.get(attrs, key_id)
+          _ ->
+            false
+        end
+      end
+    )
+    Enum.any?(true)
+  end
 end

--- a/homer/lib/homer/Utilities/contructor.ex
+++ b/homer/lib/homer/Utilities/contructor.ex
@@ -14,17 +14,57 @@ defmodule Homer.Utilities.Constructor do
   def error_on_create(_), do: true
 
 
-  def same_fk(elements, attrs, key_id) when is_list(key_id) do
-    Enum.each(key_id,
-      fn key ->
-        case Map.has_key?(elements, key) and  Map.has_key?(attrs, key) do
-          true ->
-            Map.get(elements, key) == Map.get(attrs, key_id)
-          _ ->
-            false
-        end
-      end
-    )
-    Enum.any?(true)
+  @doc """
+    If fk of attributes are same then fk of elements.
+    Fk found in list.
+    Give atom, convert in string if need.
+
+    ## Examples
+
+      iex> same_fk(nil, _, _)
+           false
+      iex> same_fk(_, nil, _)
+           false
+
+      iex> same_fk(_, _, [])
+           true
+
+      iex> same_fk(%{funding_id: 3}, %{funding_id: 3}, [:funding_id])
+           true
+
+      iex> same_fk(%{funding_id: 2}, %{funding_id: 3}, [:funding_id])
+           false
+
+      iex> same_fk(%{funding_id: 3}, %{funding_id: 3}, [:funding_id, :user_id])
+           false
+
+      iex> same_fk(%{funding_id: 3, user_id: 2}, %{funding_id: 3, user_id: 2}, [:funding_id, :user_id])
+           true
+
+      iex> same_fk(%{funding_id: 3, user_id: 1}, %{funding_id: 3, user_id: 2}, [:funding_id, :user_id])
+           false
+  """
+  def same_fk(nil, _, _), do: false
+  def same_fk(_, nil, _), do: false
+  def same_fk(_, _, []), do: true
+  def same_fk(elements, attrs, [hd_id|tl_id]) do
+    element = found_atom_in_map(elements, hd_id)
+    attr = found_atom_in_map(attrs, hd_id)
+
+    case element == attr do
+      true ->
+        same_fk(elements, attrs, tl_id)
+      _ ->
+        false
+    end
+  end
+
+  defp found_atom_in_map(map, key) do
+    case Map.has_key?(map, key) do
+      true ->
+        Map.get(map, key)
+      _ ->
+        Map.get(map, Atom.to_string(key))
+    end
   end
 end

--- a/homer/lib/homer/builders/builders.ex
+++ b/homer/lib/homer/builders/builders.ex
@@ -139,7 +139,7 @@ defmodule Homer.Builders do
     init_project = get_project!(project.id)
 
     # Not allow change funding references after init.
-    attrs = case init_project.funding_id == Map.get(attrs, :funding_id) do
+    attrs = case Homer.Utilities.Constructor.same_fk(init_project, attrs, [:funding_id]) do
       true ->
         attrs
       _ ->

--- a/homer/lib/homer/builders/builders.ex
+++ b/homer/lib/homer/builders/builders.ex
@@ -121,6 +121,7 @@ defmodule Homer.Builders do
   def update_project(%Project{} = project, attrs) do
     init_project = get_project!(project.id)
 
+    # Not allow change funding references after init.
     attrs = case init_project.funding_id == Map.get(attrs, :funding_id) do
       true ->
         attrs

--- a/homer/lib/homer/builders/project.ex
+++ b/homer/lib/homer/builders/project.ex
@@ -32,6 +32,5 @@ defmodule Homer.Builders.Project do
     |> validate_required([:name, :description, :to_raise, :funding_id])
     |> unique_constraint(:name)
     |> foreign_key_constraint(:funding_id)
-    |> cast_assoc(:steps)
   end
 end

--- a/homer/lib/homer/builders/project.ex
+++ b/homer/lib/homer/builders/project.ex
@@ -32,5 +32,6 @@ defmodule Homer.Builders.Project do
     |> validate_required([:name, :description, :to_raise, :funding_id])
     |> unique_constraint(:name)
     |> foreign_key_constraint(:funding_id)
+    |> cast_assoc(:steps)
   end
 end

--- a/homer/lib/homer/builders/project.ex
+++ b/homer/lib/homer/builders/project.ex
@@ -28,8 +28,9 @@ defmodule Homer.Builders.Project do
   @doc false
   def changeset(%Project{} = project, attrs) do
     project
-    |> cast(attrs, [:name, :description, :to_raise, :github])
-    |> validate_required([:name, :description, :to_raise])
+    |> cast(attrs, [:name, :description, :to_raise, :github, :funding_id])
+    |> validate_required([:name, :description, :to_raise, :funding_id])
     |> unique_constraint(:name)
+    |> foreign_key_constraint(:funding_id)
   end
 end

--- a/homer/lib/homer/funders/funder.ex
+++ b/homer/lib/homer/funders/funder.ex
@@ -18,7 +18,9 @@ defmodule Homer.Funders.Funder do
   @doc false
   def changeset(%Funder{} = funder, attrs) do
     funder
-    |> cast(attrs, [:status])
-    |> validate_required([:status])
+    |> cast(attrs, [:status, :user_id, :project_id])
+    |> validate_required([:status, :user_id, :project_id])
+    |> foreign_key_constraint(:user_id)
+    |> foreign_key_constraint(:project_id)
   end
 end

--- a/homer/lib/homer/funders/funders.ex
+++ b/homer/lib/homer/funders/funders.ex
@@ -45,8 +45,7 @@ defmodule Homer.Funders do
   def list_funders do
     Funder
     |> Repo.all
-    |> Repo.preload(:project)
-    |> Repo.preload(:user)
+    |> preload_funder
   end
 
   @doc """

--- a/homer/lib/homer/funders/funders.ex
+++ b/homer/lib/homer/funders/funders.ex
@@ -66,8 +66,7 @@ defmodule Homer.Funders do
   def get_funder!(id) do
     Funder
     |> Repo.get!(id)
-    |> Repo.preload(:project)
-    |> Repo.preload(:user)
+    |> preload_funder
   end
 
   @doc """
@@ -87,17 +86,16 @@ defmodule Homer.Funders do
     funder =
       case attrs do
         %{status: status}
-          -> check_funder_status(attrs, status)
+          -> insert_funder(attrs, status)
         %{"status" => status}
-          -> check_funder_status(attrs, status)
+          -> insert_funder(attrs, status)
         _
-          -> check_funder_status(nil, nil)
+          -> insert_funder(nil, nil)
       end
 
     case funder do
       {:ok, instance} ->
-        instance = %{instance | user: nil, project: nil}
-        {:ok, instance}
+        {:ok, preload_funder(instance)}
       _ -> funder
     end
   end
@@ -119,11 +117,11 @@ defmodule Homer.Funders do
   def update_funder(%Funder{} = funder, attrs) do
     case attrs do
       %{status: status}
-        -> check_funder_status(attrs, status, funder)
+        -> insert_funder(attrs, status, funder)
       %{"status" => status}
-        -> check_funder_status(attrs, status, funder)
+        -> insert_funder(attrs, status, funder)
       _
-        -> check_funder_status(nil, nil, funder)
+        -> insert_funder(nil, nil, funder)
     end
   end
 
@@ -162,15 +160,15 @@ defmodule Homer.Funders do
 ##########################################################################
 
   @doc false
-  defp check_funder_status(attrs, status, funder \\ nil) do
+  defp insert_funder(attrs, status, funder \\ nil) do
     case is_status_funder?(status) do
-      true -> insert_funder(attrs, funder)
-      _    -> insert_funder(%{status: nil}, funder)
+      true -> insert_or_update_funder(attrs, funder)
+      _    -> insert_or_update_funder(%{status: nil}, funder)
     end
   end
 
   @doc false
-  defp insert_funder(attrs, funder) do
+  defp insert_or_update_funder(attrs, funder) do
     case funder do
       nil
         -> %Funder{}
@@ -181,5 +179,12 @@ defmodule Homer.Funders do
            |> Funder.changeset(attrs)
            |> Repo.update()
     end
+  end
+
+  @doc false
+  defp preload_funder(funder) do
+    funder
+    |> Repo.preload(:user)
+    |> Repo.preload(:project)
   end
 end

--- a/homer/lib/homer/funders/funders.ex
+++ b/homer/lib/homer/funders/funders.ex
@@ -114,6 +114,8 @@ defmodule Homer.Funders do
 
   """
   def update_funder(%Funder{} = funder, attrs) do
+
+
     case attrs do
       %{status: status}
         -> insert_funder(attrs, status, funder)

--- a/homer/lib/homer/funders/funders.ex
+++ b/homer/lib/homer/funders/funders.ex
@@ -114,7 +114,15 @@ defmodule Homer.Funders do
 
   """
   def update_funder(%Funder{} = funder, attrs) do
+    init_funder = get_funder!(funder.id)
 
+    # Not allow change user and project references after init.
+    attrs = case Homer.Utilities.Constructor.same_fk(init_funder, attrs, [:user_id, :project_id])  do
+      true ->
+        attrs
+      _ ->
+        nil
+    end
 
     case attrs do
       %{status: status}

--- a/homer/lib/homer/invests/investor.ex
+++ b/homer/lib/homer/invests/investor.ex
@@ -25,7 +25,10 @@ defmodule Homer.Invests.Investor do
   @doc false
   def changeset(%Investor{} = investor, attrs) do
     investor
-    |> cast(attrs, [:comment])
-    |> validate_required([:comment])
+    |> cast(attrs, [:comment, :project_id, :user_id, :invest_allow_id])
+    |> validate_required([:comment, :project_id, :user_id, :invest_allow_id])
+    |> foreign_key_constraint(:project_id)
+    |> foreign_key_constraint(:user_id)
+    |> foreign_key_constraint(:invest_allow_id)
   end
 end

--- a/homer/lib/homer/invests/invests.ex
+++ b/homer/lib/homer/invests/invests.ex
@@ -20,10 +20,7 @@ defmodule Homer.Invests do
   def list_investors do
     Investor
     |> Repo.all
-    |> Repo.preload(:steps_validation)
-    |> Repo.preload(:user)
-    |> Repo.preload(:invest_allow)
-    |> Repo.preload(:project)
+    |> preload_investor
   end
 
   @doc """
@@ -43,11 +40,7 @@ defmodule Homer.Invests do
   def get_investor!(id) do
     Investor
     |> Repo.get!(id)
-    |> Repo.preload(:steps_validation)
-    |> Repo.preload(:steps_validation)
-    |> Repo.preload(:user)
-    |> Repo.preload(:invest_allow)
-    |> Repo.preload(:project)
+    |> preload_investor
   end
 
   @doc """
@@ -69,8 +62,7 @@ defmodule Homer.Invests do
 
     case investor do
       {:ok, instance} ->
-        instance = %{instance | steps_validation: [], user: nil, invest_allow: nil, project: nil}
-        {:ok, instance}
+        {:ok, preload_investor(instance)}
       _ -> investor
     end
   end
@@ -120,5 +112,13 @@ defmodule Homer.Invests do
   """
   def change_investor(%Investor{} = investor) do
     Investor.changeset(investor, %{})
+  end
+
+  defp preload_investor(investor) do
+    investor
+    |> Repo.preload(:steps_validation)
+    |> Repo.preload(:user)
+    |> Repo.preload(:invest_allow)
+    |> Repo.preload(:project)
   end
 end

--- a/homer/lib/homer/invests_allows/invests_allows.ex
+++ b/homer/lib/homer/invests_allows/invests_allows.ex
@@ -58,12 +58,12 @@ defmodule Homer.InvestsAllows do
   def create_invest_allow(attrs \\ %{}) do
     invest = %InvestAllow{:create_at => Ecto.DateTime.utc}
     |> InvestAllow.changeset(attrs)
-    |> Repo.insert()
+    |> Repo.insert
 
 
     case invest do
       {:ok, instance} ->
-        instance = %{instance | investors: []}
+        instance = instance |> Repo.preload(:investors)
         {:ok, instance}
       _ -> invest
     end

--- a/homer/lib/homer/monetizations/funding.ex
+++ b/homer/lib/homer/monetizations/funding.ex
@@ -30,6 +30,5 @@ defmodule Homer.Monetizations.Funding do
     |> validate_required([:name, :description, :unit, :days, :validate])
     |> cast_assoc(:invests_allows)
     |> cast_assoc(:step_templates)
-    |> cast_assoc(:projects)
   end
 end

--- a/homer/lib/homer/monetizations/funding.ex
+++ b/homer/lib/homer/monetizations/funding.ex
@@ -28,5 +28,8 @@ defmodule Homer.Monetizations.Funding do
     funding
     |> cast(attrs, [:name, :description, :unit, :days, :validate])
     |> validate_required([:name, :description, :unit, :days, :validate])
+    |> cast_assoc(:invests_allows)
+    |> cast_assoc(:step_templates)
+    |> cast_assoc(:projects)
   end
 end

--- a/homer/lib/homer/monetizations/monetizations.ex
+++ b/homer/lib/homer/monetizations/monetizations.ex
@@ -20,9 +20,7 @@ defmodule Homer.Monetizations do
   def list_fundings do
     Funding
     |> Repo.all
-    |> Repo.preload(:projects)
-    |> Repo.preload(:step_templates)
-    |> Repo.preload(:invests_allows)
+    |> preload_monetizations
   end
 
   @doc """
@@ -42,9 +40,7 @@ defmodule Homer.Monetizations do
   def get_funding!(id) do
     Funding
     |> Repo.get!(id)
-    |> Repo.preload(:projects)
-    |> Repo.preload(:step_templates)
-    |> Repo.preload(:invests_allows)
+    |> preload_monetizations
   end
 
   @doc """
@@ -62,13 +58,12 @@ defmodule Homer.Monetizations do
   """
   def create_funding(attrs \\ %{}) do
     funding = %Funding{create: Ecto.DateTime.utc}
-    |> Funding.changeset(attrs)
-    |> Repo.insert()
+              |> Funding.changeset(attrs)
+              |> Repo.insert
 
     case funding do
       {:ok, instance} ->
-        instance = %{instance | projects: [], step_templates: [], invests_allows: []}
-        {:ok, instance}
+        {:ok, preload_monetizations(instance)}
       _ -> funding
     end
   end
@@ -86,9 +81,18 @@ defmodule Homer.Monetizations do
 
   """
   def update_funding(%Funding{} = funding, attrs) do
-    funding
+    funding = funding
     |> Funding.changeset(attrs)
-    |> Repo.update()
+
+    funding = case funding do
+      {:ok, instance} ->
+        {:ok, preload_monetizations(instance)}
+      _ ->
+        funding
+    end
+
+    funding
+    |> Repo.update
   end
 
   @doc """
@@ -118,5 +122,13 @@ defmodule Homer.Monetizations do
   """
   def change_funding(%Funding{} = funding) do
     Funding.changeset(funding, %{})
+  end
+
+  @doc false
+  defp preload_monetizations(funding) do
+    funding
+    |> Repo.preload(:projects)
+    |> Repo.preload(:step_templates)
+    |> Repo.preload(:invests_allows)
   end
 end

--- a/homer/lib/homer/steps/step.ex
+++ b/homer/lib/homer/steps/step.ex
@@ -24,5 +24,6 @@ defmodule Homer.Steps.Step do
     step
     |> cast(attrs, [])
     |> validate_required([])
+    |> foreign_key_constraint(:step_template_id)
   end
 end

--- a/homer/lib/homer/steps/steps.ex
+++ b/homer/lib/homer/steps/steps.ex
@@ -56,9 +56,13 @@ defmodule Homer.Steps do
 
   """
   def create_step(attrs \\ %{}) do
-    step = %Step{create_at: Ecto.DateTime.utc}
-    |> Step.changeset(attrs)
-    |> Repo.insert()
+    step =
+      case Map.has_key?(attrs, :step_template) do
+        true -> %Step{create_at: Ecto.DateTime.utc, step_template: Map.get(attrs, :step_template)}
+        _    -> %Step{create_at: Ecto.DateTime.utc}
+      end
+      |> Step.changeset(attrs)
+      |> Repo.insert()
 
     case step do
       {:ok, instance} ->

--- a/homer/lib/homer_web/controllers/monetizations/funding_controller.ex
+++ b/homer/lib/homer_web/controllers/monetizations/funding_controller.ex
@@ -13,7 +13,6 @@ defmodule HomerWeb.Monetizations.FundingController do
 
   def create(conn, %{"funding" => funding_params}) do
     with {:ok, %Funding{} = funding} <- Monetizations.create_funding(funding_params) do
-    invest = funding.invests_allows
       conn
       |> put_status(:created)
       |> put_resp_header("location", monetizations_funding_path(conn, :show, funding))

--- a/homer/lib/homer_web/controllers/monetizations/funding_controller.ex
+++ b/homer/lib/homer_web/controllers/monetizations/funding_controller.ex
@@ -13,6 +13,7 @@ defmodule HomerWeb.Monetizations.FundingController do
 
   def create(conn, %{"funding" => funding_params}) do
     with {:ok, %Funding{} = funding} <- Monetizations.create_funding(funding_params) do
+    invest = funding.invests_allows
       conn
       |> put_status(:created)
       |> put_resp_header("location", monetizations_funding_path(conn, :show, funding))

--- a/homer/lib/homer_web/views/builders/project_view.ex
+++ b/homer/lib/homer_web/views/builders/project_view.ex
@@ -12,9 +12,9 @@ defmodule HomerWeb.Builders.ProjectView do
 
   def render("project.json", %{project: project}) do
     project = project
-              |> Homer.ViewsConverter.get_list_id(:steps)
-              |> Homer.ViewsConverter.get_list_id(:investors)
-              |> Homer.ViewsConverter.get_list_id(:funders)
+              |> Homer.ViewsConverter.get_id(:steps)
+              |> Homer.ViewsConverter.get_id(:investors)
+              |> Homer.ViewsConverter.get_id(:funders)
 
     %{id: project.id,
       name: project.name,

--- a/homer/lib/homer_web/views/builders/project_view.ex
+++ b/homer/lib/homer_web/views/builders/project_view.ex
@@ -3,11 +3,11 @@ defmodule HomerWeb.Builders.ProjectView do
   alias HomerWeb.Builders.ProjectView
 
   def render("index.json", %{projects: projects}) do
-    %{data: render_many(projects, ProjectView, "project.json")}
+    %{projects: render_many(projects, ProjectView, "project.json")}
   end
 
   def render("show.json", %{project: project}) do
-    %{data: render_one(project, ProjectView, "project.json")}
+    %{project: render_one(project, ProjectView, "project.json")}
   end
 
   def render("project.json", %{project: project}) do

--- a/homer/lib/homer_web/views/builders/project_view.ex
+++ b/homer/lib/homer_web/views/builders/project_view.ex
@@ -11,6 +11,11 @@ defmodule HomerWeb.Builders.ProjectView do
   end
 
   def render("project.json", %{project: project}) do
+    project = project
+              |> Homer.ViewsConverter.get_list_id(:steps)
+              |> Homer.ViewsConverter.get_list_id(:investors)
+              |> Homer.ViewsConverter.get_list_id(:funders)
+
     %{id: project.id,
       name: project.name,
       description: project.description,

--- a/homer/lib/homer_web/views/funders/funder_view.ex
+++ b/homer/lib/homer_web/views/funders/funder_view.ex
@@ -11,6 +11,10 @@ defmodule HomerWeb.Funders.FunderView do
   end
 
   def render("funder.json", %{funder: funder}) do
+    funder = funder
+              |> Homer.ViewsConverter.get_id(:user)
+              |> Homer.ViewsConverter.get_id(:project)
+
     %{id: funder.id,
       status: funder.status,
       user: funder.user,

--- a/homer/lib/homer_web/views/invests/investor_view.ex
+++ b/homer/lib/homer_web/views/invests/investor_view.ex
@@ -12,7 +12,7 @@ defmodule HomerWeb.Invests.InvestorView do
 
   def render("investor.json", %{investor: investor}) do
     investor = investor
-             |> Homer.ViewsConverter.get_list_id(:steps_validation)
+             |> Homer.ViewsConverter.get_id(:steps_validation)
 
     %{id: investor.id,
       comment: investor.comment,

--- a/homer/lib/homer_web/views/invests/investor_view.ex
+++ b/homer/lib/homer_web/views/invests/investor_view.ex
@@ -3,19 +3,22 @@ defmodule HomerWeb.Invests.InvestorView do
   alias HomerWeb.Invests.InvestorView
 
   def render("index.json", %{investors: investors}) do
-    %{data: render_many(investors, InvestorView, "investor.json")}
+    %{investors: render_many(investors, InvestorView, "investor.json")}
   end
 
   def render("show.json", %{investor: investor}) do
-    %{data: render_one(investor, InvestorView, "investor.json")}
+    %{investor: render_one(investor, InvestorView, "investor.json")}
   end
 
   def render("investor.json", %{investor: investor}) do
+    investor = investor
+             |> Homer.ViewsConverter.get_list_id(:steps_validation)
+
     %{id: investor.id,
       comment: investor.comment,
       steps_validation: investor.steps_validation,
-      project: investor.project,
-      user: investor.user,
-      invest_allow: investor.invest_allow}
+      project: investor.project_id,
+      user: investor.user_id,
+      invest_allow: investor.invest_allow_id}
   end
 end

--- a/homer/lib/homer_web/views/monetizations/funding_view.ex
+++ b/homer/lib/homer_web/views/monetizations/funding_view.ex
@@ -12,9 +12,9 @@ defmodule HomerWeb.Monetizations.FundingView do
 
   def render("funding.json", %{funding: funding}) do
     funding = funding
-              |> get_list_id(:invests_allows)
-              |> get_list_id(:step_templates)
-              |> get_list_id(:projects)
+              |> Homer.ViewsConverter.get_list_id(:invests_allows)
+              |> Homer.ViewsConverter.get_list_id(:step_templates)
+              |> Homer.ViewsConverter.get_list_id(:projects)
 
     %{id: funding.id,
       name: funding.name,
@@ -27,15 +27,5 @@ defmodule HomerWeb.Monetizations.FundingView do
       projects: funding.projects,
       step_templates: funding.step_templates,
       invests_allows: funding.invests_allows}
-  end
-
-  defp get_list_id(data, key) do
-    list_id = Enum.map(
-      Map.get(data, key),
-      fn invest ->
-        invest.id
-      end
-    )
-    Map.replace(data, key, list_id)
   end
 end

--- a/homer/lib/homer_web/views/monetizations/funding_view.ex
+++ b/homer/lib/homer_web/views/monetizations/funding_view.ex
@@ -12,9 +12,9 @@ defmodule HomerWeb.Monetizations.FundingView do
 
   def render("funding.json", %{funding: funding}) do
     funding = funding
-              |> Homer.ViewsConverter.get_list_id(:invests_allows)
-              |> Homer.ViewsConverter.get_list_id(:step_templates)
-              |> Homer.ViewsConverter.get_list_id(:projects)
+              |> Homer.ViewsConverter.get_id(:invests_allows)
+              |> Homer.ViewsConverter.get_id(:step_templates)
+              |> Homer.ViewsConverter.get_id(:projects)
 
     %{id: funding.id,
       name: funding.name,

--- a/homer/lib/homer_web/views/monetizations/funding_view.ex
+++ b/homer/lib/homer_web/views/monetizations/funding_view.ex
@@ -11,6 +11,11 @@ defmodule HomerWeb.Monetizations.FundingView do
   end
 
   def render("funding.json", %{funding: funding}) do
+    funding = funding
+              |> get_list_id(:invests_allows)
+              |> get_list_id(:step_templates)
+              |> get_list_id(:projects)
+
     %{id: funding.id,
       name: funding.name,
       description: funding.description,
@@ -22,5 +27,15 @@ defmodule HomerWeb.Monetizations.FundingView do
       projects: funding.projects,
       step_templates: funding.step_templates,
       invests_allows: funding.invests_allows}
+  end
+
+  defp get_list_id(data, key) do
+    list_id = Enum.map(
+      Map.get(data, key),
+      fn invest ->
+        invest.id
+      end
+    )
+    Map.replace(data, key, list_id)
   end
 end

--- a/homer/lib/homer_web/views/views_converter.ex
+++ b/homer/lib/homer_web/views/views_converter.ex
@@ -3,30 +3,46 @@ defmodule Homer.ViewsConverter do
     Get data map who contain list field at key and return list of id of each list element.
 
     ## Examples
-      iex> get_list_id(%{li: [%{id: 3}]}, :li)
+      iex> get_id(%{li: [%{id: 3}]}, :li)
            %{li: [3]}
 
-      iex> get_list_id(%{li: [%{id: 3}, %{id: 5}]}, :li)
+      iex> get_id(%{li: [%{id: 3}, %{id: 5}]}, :li)
            %{li: [3, 5]}
 
-      iex> get_list_id(%{li: [%{other_name: 3}, %{id: 5}]}, :li)
+      iex> get_id(%{li: %{id: 3}}, :li)
+           %{li: 3}
+
+      iex> get_id(%{li: [%{other_name: 3}, %{id: 5}]}, :li)
            nil
 
-      iex> get_list_id(nil, [])
+      iex> get_id(%{li: %{other_name: 3}, %{id: 5}}, :li)
+           nil
+
+      iex> get_id(nil, [])
            nil
 
   """
-  def get_list_id(data, key) when is_map(data) do
+  def get_id(data, key) when is_map(data) do
     case Map.has_key?(data, key) do
       true ->
-        list_id = Enum.map(Map.get(data, key), fn invest -> invest.id end)
-        case Enum.any?(list_id, fn elem -> elem == nil end) do
-          false ->
-            Map.replace(data, key, list_id)
-          _ ->
-            nil
-        end
+        get_id(data, key, Map.get(data, key))
       _ -> nil
     end
+  end
+
+  defp get_id(data, key, li) when is_list(li) do
+    list_id = Enum.map(li, fn invest -> invest.id end)
+    case Enum.any?(list_id, fn elem -> elem == nil end) do
+      false ->
+        Map.replace(data, key, list_id)
+      _ ->
+        nil
+    end
+  end
+  defp get_id(data, key, element) when is_map(element) do
+    Map.replace(data, key, element.id)
+  end
+  defp get_id(_, _, _) do
+    nil
   end
 end

--- a/homer/lib/homer_web/views/views_converter.ex
+++ b/homer/lib/homer_web/views/views_converter.ex
@@ -1,0 +1,32 @@
+defmodule Homer.ViewsConverter do
+  @doc """
+    Get data map who contain list field at key and return list of id of each list element.
+
+    ## Examples
+      iex> get_list_id(%{li: [%{id: 3}]}, :li)
+           %{li: [3]}
+
+      iex> get_list_id(%{li: [%{id: 3}, %{id: 5}]}, :li)
+           %{li: [3, 5]}
+
+      iex> get_list_id(%{li: [%{other_name: 3}, %{id: 5}]}, :li)
+           nil
+
+      iex> get_list_id(nil, [])
+           nil
+
+  """
+  def get_list_id(data, key) when is_map(data) do
+    case Map.has_key?(data, key) do
+      true ->
+        list_id = Enum.map(Map.get(data, key), fn invest -> invest.id end)
+        case Enum.any?(list_id, fn elem -> elem == nil end) do
+          false ->
+            Map.replace(data, key, list_id)
+          _ ->
+            nil
+        end
+      _ -> nil
+    end
+  end
+end

--- a/homer/priv/repo/migrations/20170825154121_update_relation_funding.exs
+++ b/homer/priv/repo/migrations/20170825154121_update_relation_funding.exs
@@ -1,0 +1,20 @@
+defmodule Homer.Repo.Migrations.UpdateRelationFunding do
+  use Ecto.Migration
+
+  def change do
+    alter table(:invests_allows) do
+      remove :funding_id
+      add :funding_id, references(:fundings, on_delete: :delete_all)
+    end
+
+    alter table(:projects) do
+      remove :funding_id
+      add :funding_id, references(:fundings, on_delete: :nothing)
+    end
+
+    alter table(:step_templates) do
+      remove :funding_id
+      add :funding_id, references(:fundings, on_delete: :delete_all)
+    end
+  end
+end

--- a/homer/test/homer/accounts/accounts_test.exs
+++ b/homer/test/homer/accounts/accounts_test.exs
@@ -10,7 +10,12 @@ defmodule Homer.AccountsTest do
     @update_attrs %{email: "some updated email", password: "some updated password"}
     @invalid_attrs %{email: nil, password: nil}
 
-    def user_fixture(attrs \\ %{}) do
+    def user_fixture(attrs \\ %{}, new_name \\ false) do
+      attrs = case new_name do
+        true -> Map.put(attrs, :email, "#{Enum.random(0..4242)}")
+        _ -> attrs
+      end
+
       {:ok, user} =
         attrs
         |> Enum.into(@valid_attrs)

--- a/homer/test/homer/builders/builders_test.exs
+++ b/homer/test/homer/builders/builders_test.exs
@@ -10,7 +10,12 @@ defmodule Homer.BuildersTest do
     @update_attrs %{name: "some update name", description: "some updated description", to_raise: 43, github: "some github"}
     @invalid_attrs %{name: nil, description: nil, to_raise: nil}
 
-    def project_fixture(attrs \\ %{}) do
+    def project_fixture(attrs \\ %{}, new_name \\ false) do
+      attrs = case new_name do
+        true -> Map.put(attrs, :name, "#{Enum.random(0..4242)}")
+        _ -> attrs
+      end
+
       {:ok, project} =
         Enum.into(attrs, get_valid_attrs())
         |> Builders.create_project()

--- a/homer/test/homer/builders/builders_test.exs
+++ b/homer/test/homer/builders/builders_test.exs
@@ -6,17 +6,13 @@ defmodule Homer.BuildersTest do
   describe "projects" do
     alias Homer.Builders.Project
 
-    @valid_attrs %{name: "some name", description: "some description", to_raise: 42, funding_id: 1}
-    @update_attrs %{name: "some update name", description: "some updated description", to_raise: 43, github: "some github", funding_id: 1}
+    @valid_attrs %{name: "some name", description: "some description", to_raise: 42}
+    @update_attrs %{name: "some update name", description: "some updated description", to_raise: 43, github: "some github"}
     @invalid_attrs %{name: nil, description: nil, to_raise: nil}
 
     def project_fixture(attrs \\ %{}) do
-      funding = Homer.MonetizationsTest.funding_fixture
-
       {:ok, project} =
-        attrs
-        |> Enum.into(@valid_attrs)
-        |> Map.put(:funding_id, funding.id)
+        Enum.into(attrs, get_valid_attrs())
         |> Builders.create_project()
 
       project
@@ -108,11 +104,18 @@ defmodule Homer.BuildersTest do
       project = %{init_project | create_at: "#{Ecto.DateTime.to_iso8601(init_project.create_at)}.000000Z", status: init_project.status}
       assert project == update_project
     end
-  end
 
-  defp get_valid_attrs(attrs) do
-    funding = Homer.MonetizationsTest.funding_fixture
+    defp get_valid_attrs(attrs \\ @valid_attrs) do
+      funding = Homer.MonetizationsTest.funding_fixture
 
-    Map.put(attrs, :funding_id, funding.id)
+      steps = Enum.map(
+        funding.step_templates,
+        fn step_template -> %{step_template_id: step_template.id} end
+      )
+
+      attrs
+      |> Map.put(:steps, steps)
+      |> Map.put(:funding_id, funding.id)
+    end
   end
 end

--- a/homer/test/homer/builders/builders_test.exs
+++ b/homer/test/homer/builders/builders_test.exs
@@ -6,14 +6,17 @@ defmodule Homer.BuildersTest do
   describe "projects" do
     alias Homer.Builders.Project
 
-    @valid_attrs %{name: "some name", description: "some description", to_raise: 42}
-    @update_attrs %{name: "some update name", description: "some updated description", to_raise: 43, github: "some github"}
+    @valid_attrs %{name: "some name", description: "some description", to_raise: 42, funding_id: 1}
+    @update_attrs %{name: "some update name", description: "some updated description", to_raise: 43, github: "some github", funding_id: 1}
     @invalid_attrs %{name: nil, description: nil, to_raise: nil}
 
     def project_fixture(attrs \\ %{}) do
+      funding = Homer.MonetizationsTest.funding_fixture
+
       {:ok, project} =
         attrs
         |> Enum.into(@valid_attrs)
+        |> Map.put(:funding_id, funding.id)
         |> Builders.create_project()
 
       project
@@ -41,7 +44,7 @@ defmodule Homer.BuildersTest do
     end
 
     test "create_project/1 with valid data creates a project" do
-      assert {:ok, %Project{} = project} = Builders.create_project(@valid_attrs)
+      assert {:ok, %Project{} = project} = Builders.create_project(get_valid_attrs(@valid_attrs))
       assert project.name == "some name"
       assert Ecto.DateTime.to_iso8601(project.create_at) == Ecto.DateTime.to_iso8601(Ecto.DateTime.utc)
       assert project.description == "some description"
@@ -54,12 +57,13 @@ defmodule Homer.BuildersTest do
     end
 
     test "create_project/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Builders.create_project(@invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Builders.create_project(get_valid_attrs(@invalid_attrs))
     end
 
     test "update_project/2 with valid data updates the project" do
       init_project = project_fixture()
-      assert {:ok, project} = Builders.update_project(init_project, @update_attrs)
+      project_attr = %{get_valid_attrs(@update_attrs) | funding_id: init_project.funding_id}
+      assert {:ok, project} = Builders.update_project(init_project, project_attr)
       assert %Project{} = project
       assert project.name == "some update name"
       assert project.create_at == init_project.create_at
@@ -74,7 +78,7 @@ defmodule Homer.BuildersTest do
 
     test "update_project/2 with invalid data returns error changeset" do
       init_project = project_fixture()
-      assert {:error, %Ecto.Changeset{}} = Builders.update_project(init_project, @invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Builders.update_project(init_project, get_valid_attrs(@invalid_attrs))
       update_project = Builders.get_project!(init_project.id)
       update_project = %{update_project | create_at: DateTime.to_iso8601(update_project.create_at)}
       project = %{init_project | create_at: "#{Ecto.DateTime.to_iso8601(init_project.create_at)}.000000Z", status: init_project.status}
@@ -91,5 +95,24 @@ defmodule Homer.BuildersTest do
       project = project_fixture()
       assert %Ecto.Changeset{} = Builders.change_project(project)
     end
+
+    test "create_project/2 with invalid fk" do
+      assert {:error, %Ecto.Changeset{}} = Builders.create_project(@valid_attrs)
+    end
+
+    test "update_project/2 with invalid other fk" do
+      init_project = project_fixture()
+      assert {:error, %Ecto.Changeset{}} = Builders.update_project(init_project, get_valid_attrs(@valid_attrs))
+      update_project = Builders.get_project!(init_project.id)
+      update_project = %{update_project | create_at: DateTime.to_iso8601(update_project.create_at)}
+      project = %{init_project | create_at: "#{Ecto.DateTime.to_iso8601(init_project.create_at)}.000000Z", status: init_project.status}
+      assert project == update_project
+    end
+  end
+
+  defp get_valid_attrs(attrs) do
+    funding = Homer.MonetizationsTest.funding_fixture
+
+    Map.put(attrs, :funding_id, funding.id)
   end
 end

--- a/homer/test/homer/builders/builders_test.exs
+++ b/homer/test/homer/builders/builders_test.exs
@@ -56,6 +56,12 @@ defmodule Homer.BuildersTest do
       assert {:error, %Ecto.Changeset{}} = Builders.create_project(get_valid_attrs(@invalid_attrs))
     end
 
+    test "create_project/1 with invalid funding ref in step returns error changeset" do
+      attrs = get_valid_attrs(@valid_attrs)
+      attrs = Map.put(attrs, :funding_id, attrs.funding_id - 1)
+      assert {:error, %Ecto.Changeset{}} = Builders.create_project(attrs)
+    end
+
     test "update_project/2 with valid data updates the project" do
       init_project = project_fixture()
       project_attr = %{get_valid_attrs(@update_attrs) | funding_id: init_project.funding_id}

--- a/homer/test/homer/funders/funders_test.exs
+++ b/homer/test/homer/funders/funders_test.exs
@@ -34,14 +34,23 @@ defmodule Homer.FundersTest do
     end
 
     test "create_funder/1 with valid data creates a funder" do
-      assert {:ok, %Funder{} = funder} = Funders.create_funder(@valid_attrs)
+      assert {:ok, %Funder{} = funder} = Funders.create_funder(get_valid_attrs())
       assert funder.status == "Creator"
-      assert funder.user == nil
-      assert funder.project == nil
+      assert funder.user != nil
+      assert funder.project != nil
     end
 
     test "create_funder/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Funders.create_funder(@invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Funders.create_funder(get_valid_attrs(@invalid_attrs))
+
+      random_number =  :rand.uniform(100000)
+      attrs = get_valid_attrs(@valid_attrs)
+
+      bad_project = Map.put(attrs, :project_id, random_number)
+      assert {:error, %Ecto.Changeset{}} = Funders.create_funder(bad_project)
+
+      bad_user = Map.put(attrs, :user_id, random_number)
+      assert {:error, %Ecto.Changeset{}} = Funders.create_funder(bad_user)
     end
 
     test "update_funder/2 with valid data updates the funder" do
@@ -49,8 +58,8 @@ defmodule Homer.FundersTest do
       assert {:ok, funder} = Funders.update_funder(funder, @update_attrs)
       assert %Funder{} = funder
       assert funder.status == "Worker"
-      assert funder.user == nil
-      assert funder.project == nil
+      assert funder.user != nil
+      assert funder.project != nil
     end
 
     test "update_funder/2 with invalid data returns error changeset" do

--- a/homer/test/homer/funders/funders_test.exs
+++ b/homer/test/homer/funders/funders_test.exs
@@ -66,6 +66,16 @@ defmodule Homer.FundersTest do
       funder = funder_fixture()
       assert {:error, %Ecto.Changeset{}} = Funders.update_funder(funder, @invalid_attrs)
       assert funder == Funders.get_funder!(funder.id)
+
+      other_funder = funder_fixture() # Other funder with other user and project
+      funder_with_new_user = Map.put(@update_attrs, :user_id, Map.get(other_funder, :user_id))
+      funder_with_new_project = Map.put(@update_attrs, :project_id, Map.get(other_funder, :project_id))
+
+      assert {:error, %Ecto.Changeset{}} = Funders.update_funder(funder, funder_with_new_user)
+      assert funder == Funders.get_funder!(funder.id)
+
+      assert {:error, %Ecto.Changeset{}} = Funders.update_funder(funder, funder_with_new_project)
+      assert funder == Funders.get_funder!(funder.id)
     end
 
     test "delete_funder/1 deletes the funder" do

--- a/homer/test/homer/funders/funders_test.exs
+++ b/homer/test/homer/funders/funders_test.exs
@@ -17,6 +17,7 @@ defmodule Homer.FundersTest do
       {:ok, funder} =
         attrs
         |> Enum.into(@valid_attrs)
+        |> Enum.into(get_valid_attrs())
         |> Funders.create_funder()
 
       funder
@@ -81,6 +82,15 @@ defmodule Homer.FundersTest do
         @invalid_status_funder,
         fn status -> assert true != Funders.is_status_funder?(status) end
       )
+    end
+
+    defp get_valid_attrs(attrs \\ @valid_attrs) do
+      user = Homer.AccountsTest.user_fixture(%{}, true)
+      project = Homer.BuildersTest.project_fixture(%{}, true)
+
+      attrs
+      |> Map.put(:user_id, user.id)
+      |> Map.put(:project_id, project.id)
     end
   end
 end

--- a/homer/test/homer/funders/funders_test.exs
+++ b/homer/test/homer/funders/funders_test.exs
@@ -54,12 +54,13 @@ defmodule Homer.FundersTest do
     end
 
     test "update_funder/2 with valid data updates the funder" do
-      funder = funder_fixture()
-      assert {:ok, funder} = Funders.update_funder(funder, @update_attrs)
+      initial_funder = funder_fixture()
+      attrs = get_valid_attrs(@update_attrs, initial_funder)
+      assert {:ok, funder} = Funders.update_funder(initial_funder, attrs)
       assert %Funder{} = funder
       assert funder.status == "Worker"
-      assert funder.user != nil
-      assert funder.project != nil
+      assert funder.user != initial_funder.user_id
+      assert funder.project != initial_funder.project_id
     end
 
     test "update_funder/2 with invalid data returns error changeset" do
@@ -103,13 +104,20 @@ defmodule Homer.FundersTest do
       )
     end
 
-    defp get_valid_attrs(attrs \\ @valid_attrs) do
-      user = Homer.AccountsTest.user_fixture(%{}, true)
-      project = Homer.BuildersTest.project_fixture(%{}, true)
+    defp get_valid_attrs(attrs \\ @valid_attrs, funder \\ nil) do
+      case nil !== funder do
+        true ->
+          attrs
+          |> Map.put(:user_id, funder.user_id)
+          |> Map.put(:project_id, funder.project_id)
+        _ ->
+          user = Homer.AccountsTest.user_fixture(%{}, true)
+          project = Homer.BuildersTest.project_fixture(%{}, true)
 
-      attrs
-      |> Map.put(:user_id, user.id)
-      |> Map.put(:project_id, project.id)
+          attrs
+          |> Map.put(:user_id, user.id)
+          |> Map.put(:project_id, project.id)
+      end
     end
   end
 end

--- a/homer/test/homer/invests/invests_test.exs
+++ b/homer/test/homer/invests/invests_test.exs
@@ -13,7 +13,7 @@ defmodule Homer.InvestsTest do
     def investor_fixture(attrs \\ %{}) do
       {:ok, investor} =
         attrs
-        |> Enum.into(@valid_attrs)
+        |> Enum.into(valid_attrs())
         |> Invests.create_investor()
 
       investor
@@ -30,18 +30,18 @@ defmodule Homer.InvestsTest do
     end
 
     test "create_investor/1 with valid data creates a investor" do
-      assert {:ok, %Investor{} = investor} = Invests.create_investor(@valid_attrs)
+      assert {:ok, %Investor{} = investor} = Invests.create_investor(valid_attrs())
       assert investor.comment == "some comment"
       assert investor.steps_validation == []
     end
 
     test "create_investor/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Invests.create_investor(@invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Invests.create_investor(valid_attrs(@invalid_attrs))
     end
 
     test "update_investor/2 with valid data updates the investor" do
       investor = investor_fixture()
-      assert {:ok, investor} = Invests.update_investor(investor, @update_attrs)
+      assert {:ok, investor} = Invests.update_investor(investor, valid_attrs(@update_attrs))
       assert %Investor{} = investor
       assert investor.comment == "some updated comment"
       assert investor.steps_validation == []
@@ -49,7 +49,7 @@ defmodule Homer.InvestsTest do
 
     test "update_investor/2 with invalid data returns error changeset" do
       investor = investor_fixture()
-      assert {:error, %Ecto.Changeset{}} = Invests.update_investor(investor, @invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Invests.update_investor(investor, valid_attrs(@invalid_attrs))
       assert investor == Invests.get_investor!(investor.id)
     end
 
@@ -62,6 +62,19 @@ defmodule Homer.InvestsTest do
     test "change_investor/1 returns a investor changeset" do
       investor = investor_fixture()
       assert %Ecto.Changeset{} = Invests.change_investor(investor)
+    end
+
+    defp valid_attrs(attrs \\ @valid_attrs) do
+      project = Homer.BuildersTest.project_fixture(%{}, true)
+      user = Homer.AccountsTest.user_fixture(%{}, true)
+      invests_allow = Homer.InvestsAllowsTest.invest_allow_fixture
+
+      attrs = attrs
+        |> Map.put(:project_id, project.id)
+        |> Map.put(:user_id, user.id)
+        |> Map.put(:invest_allow_id, invests_allow.id)
+
+      attrs
     end
   end
 end

--- a/homer/test/homer/model_utilities_test.exs
+++ b/homer/test/homer/model_utilities_test.exs
@@ -1,0 +1,31 @@
+defmodule Homer.ModelUtilitiesTest do
+  use Homer.DataCase
+
+  def test_length(list_1, list_2) when is_list(list_2) do
+    v1 = length list_1
+    v2 = length list_2
+    assert v1 == v2
+  end
+
+  def test_length(list_1, nb) when is_integer(nb) do
+    v1 = length list_1
+    assert v1 == nb
+  end
+
+  @doc """
+    Apply length test on tuple list.
+
+    iex> test_lengths(%{k: []}, [{:k, 0}])
+
+    iex> test_lengths(%{k: [1, 2], k2: [1]}, [{:k, 2}, {:k2, 1}])
+
+    iex> test_lengths(%{k: []}, [{:k, 2}])
+         error
+  """
+  def test_lengths(map, list) do
+    Enum.map(
+      list,
+      fn {key, value} -> test_length(Map.get(map, key), value) end
+    )
+  end
+end

--- a/homer/test/homer/monetizations/monetizations_test.exs
+++ b/homer/test/homer/monetizations/monetizations_test.exs
@@ -6,7 +6,16 @@ defmodule Homer.MonetizationsTest do
   describe "fundings" do
     alias Homer.Monetizations.Funding
 
-    @valid_attrs %{description: "some description", name: "some name", unit: "some unit", days: 10, validate: 80}
+    @valid_attrs %{description: "some description", name: "some name", unit: "some unit", days: 10, validate: 80,
+      invests_allows: [
+        %{description: "some description for funding", invest: 42, name: "some name for funding"},
+        %{description: "again some description for funding", invest: 42, name: "again some name for funding"}
+      ],
+      step_templates: [
+        %{description: "some description", name: "some name", rank: 42},
+        %{description: "again some description", name: "again some name", rank: 42}
+      ]
+    }
     @update_attrs %{description: "some updated description", name: "some updated name", unit: "some updated unit", days: 15, validate: 85}
     @invalid_attrs %{description: nil, name: nil, unit: nil, days: nil, validate: nil}
     @invalid_attrs_create [%{description: nil, name: "name", unit: "unit", days: 10, validate: 80},
@@ -56,8 +65,8 @@ defmodule Homer.MonetizationsTest do
       assert funding.days == 10
       assert funding.validate == 80
       assert funding.projects == []
-      assert funding.step_templates == []
-      assert funding.invests_allows == []
+      test_length(funding.step_templates, 2)
+      test_length(funding.invests_allows, 2)
     end
 
     test "create_funding/1 with invalid data returns error changeset" do
@@ -78,9 +87,9 @@ defmodule Homer.MonetizationsTest do
       assert funding.valid == false
       assert funding.days == 15
       assert funding.validate == 85
-      assert funding.projects == []
-      assert funding.step_templates == []
-      assert funding.invests_allows == []
+      assert funding.projects == init_funding.projects
+      test_length(init_funding.step_templates, funding.step_templates)
+      test_length(init_funding.invests_allows, funding.invests_allows)
     end
 
     test "update_funding/2 with invalid data returns error changeset" do
@@ -103,5 +112,21 @@ defmodule Homer.MonetizationsTest do
       funding = funding_fixture()
       assert %Ecto.Changeset{} = Monetizations.change_funding(funding)
     end
+  end
+
+  #############################################################################################
+  #############################################################################################
+  #############################################################################################
+  #############################################################################################
+
+  defp test_length(list_1, list_2) when is_list(list_2) do
+    v1 = length list_1
+    v2 = length list_2
+    assert v1 == v2
+  end
+
+  defp test_length(list_1, nb) when is_integer(nb) do
+    v1 = length list_1
+    assert v1 == nb
   end
 end

--- a/homer/test/homer/monetizations/monetizations_test.exs
+++ b/homer/test/homer/monetizations/monetizations_test.exs
@@ -65,8 +65,8 @@ defmodule Homer.MonetizationsTest do
       assert funding.days == 10
       assert funding.validate == 80
       assert funding.projects == []
-      test_length(funding.step_templates, 2)
-      test_length(funding.invests_allows, 2)
+      Homer.ModelUtilitiesTest.test_length(funding.step_templates, 2)
+      Homer.ModelUtilitiesTest.test_length(funding.invests_allows, 2)
     end
 
     test "create_funding/1 with invalid data returns error changeset" do
@@ -88,8 +88,8 @@ defmodule Homer.MonetizationsTest do
       assert funding.days == 15
       assert funding.validate == 85
       assert funding.projects == init_funding.projects
-      test_length(init_funding.step_templates, funding.step_templates)
-      test_length(init_funding.invests_allows, funding.invests_allows)
+      Homer.ModelUtilitiesTest.test_length(init_funding.step_templates, funding.step_templates)
+      Homer.ModelUtilitiesTest.test_length(init_funding.invests_allows, funding.invests_allows)
     end
 
     test "update_funding/2 with invalid data returns error changeset" do
@@ -112,21 +112,5 @@ defmodule Homer.MonetizationsTest do
       funding = funding_fixture()
       assert %Ecto.Changeset{} = Monetizations.change_funding(funding)
     end
-  end
-
-  #############################################################################################
-  #############################################################################################
-  #############################################################################################
-  #############################################################################################
-
-  defp test_length(list_1, list_2) when is_list(list_2) do
-    v1 = length list_1
-    v2 = length list_2
-    assert v1 == v2
-  end
-
-  defp test_length(list_1, nb) when is_integer(nb) do
-    v1 = length list_1
-    assert v1 == nb
   end
 end

--- a/homer/test/homer_web/controllers/builders/project_controller_test.exs
+++ b/homer/test/homer_web/controllers/builders/project_controller_test.exs
@@ -76,9 +76,8 @@ defmodule HomerWeb.Builders.ProjectControllerTest do
   describe "update project" do
     setup [:create_project]
 
-    test "renders project when data is valid", %{conn: conn, project: %Project{id: id, create_at: create_at, funding_id: funding_id} = project} do
-      project_attrs = Map.put(create_attrs(@update_attrs), :funding_id, funding_id)
-      conn = put conn, builders_project_path(conn, :update, project), project: project_attrs
+    test "renders project when data is valid", %{conn: conn, project: %Project{id: id, create_at: create_at} = project} do
+      conn = put conn, builders_project_path(conn, :update, project), project: create_attrs(@update_attrs)
       assert json_response(conn, 422)["errors"] != %{}
 
       conn = get conn, builders_project_path(conn, :show, id)

--- a/homer/test/homer_web/controllers/builders/project_controller_test.exs
+++ b/homer/test/homer_web/controllers/builders/project_controller_test.exs
@@ -23,7 +23,7 @@ defmodule HomerWeb.Builders.ProjectControllerTest do
 
   def fixture(:project) do
     {:ok, project} = Builders.create_project(create_attrs())
-    
+
     project
   end
 

--- a/homer/test/homer_web/controllers/builders/project_controller_test.exs
+++ b/homer/test/homer_web/controllers/builders/project_controller_test.exs
@@ -63,6 +63,14 @@ defmodule HomerWeb.Builders.ProjectControllerTest do
       conn = post conn, builders_project_path(conn, :create), project: create_attrs(@invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
+
+    test "renders errors when funding_id of step is invalid", %{conn: conn} do
+      attrs = create_attrs()
+      attrs = Map.put(attrs, :funding_id, attrs.funding_id - 1)
+      conn = post conn, builders_project_path(conn, :create), project: attrs
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
   end
 
   describe "update project" do

--- a/homer/test/homer_web/controllers/controler_utilities_test.exs
+++ b/homer/test/homer_web/controllers/controler_utilities_test.exs
@@ -1,4 +1,19 @@
 defmodule Homer.ControllerUtilitiesTest do
+  @doc """
+    Get map and list of key struct in map.
+    Each key is a list of struct.
+    Each struct have a id.
+    Return list with id
+
+    ## Examples
+
+      iex> convert_fk(%{elem1: [%{id: 2}, %{id: 3}]}, [:elem1])
+           %{elem1: [2, 3]}
+
+      iex> convert_fk(%{elem1: [%{id: 2}, %{id: 3}], elem2: [%{id: 2}, %{id: 3}]}, [:elem1, :elem2])
+           %{elem1: [2, 3], elem2: [2, 3]}
+
+  """
   def convert_fk(map, []), do: map
   def convert_fk(map, [key | tl]) do
     Homer.ViewsConverter.get_list_id(map, key)

--- a/homer/test/homer_web/controllers/controler_utilities_test.exs
+++ b/homer/test/homer_web/controllers/controler_utilities_test.exs
@@ -1,0 +1,7 @@
+defmodule Homer.ControllerUtilitiesTest do
+  def convert_fk(map, []), do: map
+  def convert_fk(map, [key | tl]) do
+    Homer.ViewsConverter.get_list_id(map, key)
+    |> convert_fk(tl)
+  end
+end

--- a/homer/test/homer_web/controllers/controler_utilities_test.exs
+++ b/homer/test/homer_web/controllers/controler_utilities_test.exs
@@ -16,7 +16,7 @@ defmodule Homer.ControllerUtilitiesTest do
   """
   def convert_fk(map, []), do: map
   def convert_fk(map, [key | tl]) do
-    Homer.ViewsConverter.get_list_id(map, key)
+    Homer.ViewsConverter.get_id(map, key)
     |> convert_fk(tl)
   end
 end

--- a/homer/test/homer_web/controllers/funders/funder_controller_test.exs
+++ b/homer/test/homer_web/controllers/funders/funder_controller_test.exs
@@ -50,10 +50,13 @@ defmodule HomerWeb.Funders.FunderControllerTest do
     test "renders errors when fk is invalid", %{conn: conn} do
       funder_attrs = valid_attrs(@create_attrs)
 
-      conn = post conn, funders_funder_path(conn, :create), funder: Map.put(funder_attrs, :user_id, Map.get(funder_attrs, :user_id) -1)
+      bad_user_id = Map.put(funder_attrs, :user_id, Map.get(funder_attrs, :user_id) - 1)
+      bad_project_id = Map.put(funder_attrs, :project_id, Map.get(funder_attrs, :project_id) - 1)
+
+      conn = post conn, funders_funder_path(conn, :create), funder: bad_user_id
       assert json_response(conn, 422)["errors"] != %{}
 
-      conn = post conn, funders_funder_path(conn, :create), funder: Map.put(funder_attrs, :project_id, Map.get(funder_attrs, :project_id) -1)
+      conn = post conn, funders_funder_path(conn, :create), funder: bad_project_id
       assert json_response(conn, 422)["errors"] != %{}
     end
 

--- a/homer/test/homer_web/controllers/funders/funder_controller_test.exs
+++ b/homer/test/homer_web/controllers/funders/funder_controller_test.exs
@@ -9,7 +9,7 @@ defmodule HomerWeb.Funders.FunderControllerTest do
   @invalid_attrs %{status: nil}
 
   def fixture(:funder) do
-    {:ok, funder} = Funders.create_funder(@create_attrs)
+    {:ok, funder} = Funders.create_funder(valid_attrs())
     funder
   end
 
@@ -26,40 +26,61 @@ defmodule HomerWeb.Funders.FunderControllerTest do
 
   describe "create funder" do
     test "renders funder when data is valid", %{conn: conn} do
-      conn = post conn, funders_funder_path(conn, :create), funder: @create_attrs
+      conn = post conn, funders_funder_path(conn, :create), funder: valid_attrs(@create_attrs)
       assert %{"id" => id} = json_response(conn, 201)["funder"]
 
       conn = get conn, funders_funder_path(conn, :show, id)
-      assert json_response(conn, 200)["funder"] == %{
+      funder = json_response(conn, 200)["funder"]
+
+      assert Map.get(funder, "project") != nil
+      assert Map.get(funder, "user") != nil
+
+      assert funder == %{
         "id" => id,
         "status" => "Creator",
-        "project" => nil,
-        "user" => nil}
+        "project" => Map.get(funder, "project"),
+        "user" => Map.get(funder, "user")}
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
-      conn = post conn, funders_funder_path(conn, :create), funder: @invalid_attrs
+      conn = post conn, funders_funder_path(conn, :create), funder: valid_attrs(@invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
+
+    test "renders errors when fk is invalid", %{conn: conn} do
+      funder_attrs = valid_attrs(@create_attrs)
+
+      conn = post conn, funders_funder_path(conn, :create), funder: Map.put(funder_attrs, :user_id, Map.get(funder_attrs, :user_id) -1)
+      assert json_response(conn, 422)["errors"] != %{}
+
+      conn = post conn, funders_funder_path(conn, :create), funder: Map.put(funder_attrs, :project_id, Map.get(funder_attrs, :project_id) -1)
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+
   end
 
   describe "update funder" do
     setup [:create_funder]
 
     test "renders funder when data is valid", %{conn: conn, funder: %Funder{id: id} = funder} do
-      conn = put conn, funders_funder_path(conn, :update, funder), funder: @update_attrs
+      conn = put conn, funders_funder_path(conn, :update, funder), funder: valid_attrs(@update_attrs)
       assert %{"id" => ^id} = json_response(conn, 200)["funder"]
 
       conn = get conn, funders_funder_path(conn, :show, id)
-      assert json_response(conn, 200)["funder"] == %{
+      funder = json_response(conn, 200)["funder"]
+
+      assert Map.get(funder, "project") != nil
+      assert Map.get(funder, "user") != nil
+
+      assert funder == %{
         "id" => id,
         "status" => "Worker",
-        "project" => nil,
-        "user" => nil}
+        "project" => Map.get(funder, "project"),
+        "user" => Map.get(funder, "user")}
     end
 
     test "renders errors when data is invalid", %{conn: conn, funder: funder} do
-      conn = put conn, funders_funder_path(conn, :update, funder), funder: @invalid_attrs
+      conn = put conn, funders_funder_path(conn, :update, funder), funder: valid_attrs(@invalid_attrs)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -79,5 +100,16 @@ defmodule HomerWeb.Funders.FunderControllerTest do
   defp create_funder(_) do
     funder = fixture(:funder)
     {:ok, funder: funder}
+  end
+
+  defp valid_attrs(attrs \\ @create_attrs) do
+    project = Homer.BuildersTest.project_fixture(%{}, true)
+    user = Homer.AccountsTest.user_fixture(%{}, true)
+
+    attrs = attrs
+            |> Map.put(:project_id, project.id)
+            |> Map.put(:user_id, user.id)
+
+    attrs
   end
 end

--- a/homer/test/homer_web/controllers/funders/funder_controller_test.exs
+++ b/homer/test/homer_web/controllers/funders/funder_controller_test.exs
@@ -66,7 +66,7 @@ defmodule HomerWeb.Funders.FunderControllerTest do
     setup [:create_funder]
 
     test "renders funder when data is valid", %{conn: conn, funder: %Funder{id: id} = funder} do
-      conn = put conn, funders_funder_path(conn, :update, funder), funder: valid_attrs(@update_attrs)
+      conn = put conn, funders_funder_path(conn, :update, funder), funder: valid_attrs(@update_attrs, funder)
       assert %{"id" => ^id} = json_response(conn, 200)["funder"]
 
       conn = get conn, funders_funder_path(conn, :show, id)
@@ -105,14 +105,18 @@ defmodule HomerWeb.Funders.FunderControllerTest do
     {:ok, funder: funder}
   end
 
-  defp valid_attrs(attrs \\ @create_attrs) do
-    project = Homer.BuildersTest.project_fixture(%{}, true)
-    user = Homer.AccountsTest.user_fixture(%{}, true)
-
-    attrs = attrs
-            |> Map.put(:project_id, project.id)
-            |> Map.put(:user_id, user.id)
-
-    attrs
+  defp valid_attrs(attrs \\ @create_attrs, funder \\ nil) do
+    case nil !== funder do
+      true ->
+        attrs
+          |> Map.put(:project_id, funder.project_id)
+          |> Map.put(:user_id, funder.user_id)
+      _ ->
+        project = Homer.BuildersTest.project_fixture(%{}, true)
+        user = Homer.AccountsTest.user_fixture(%{}, true)
+        attrs
+          |> Map.put(:project_id, project.id)
+          |> Map.put(:user_id, user.id)
+    end
   end
 end

--- a/homer/test/homer_web/controllers/monetizations/funding_controller_test.exs
+++ b/homer/test/homer_web/controllers/monetizations/funding_controller_test.exs
@@ -4,8 +4,17 @@ defmodule HomerWeb.Monetizations.FundingControllerTest do
   alias Homer.Monetizations
   alias Homer.Monetizations.Funding
 
-  @create_attrs %{description: "some description", name: "some name", unit: "some unit", days: 10, validate: 80}
-  @update_attrs %{description: "some updated description", name: "some updated name", unit: "some updated unit", days: 15, validate: 85}
+  @create_attrs %{description: "some description", name: "some name", unit: "some unit", days: 10, validate: 80,
+    invests_allows: [
+      %{description: "some description for funding", invest: 42, name: "some name for funding"},
+      %{description: "again some description for funding", invest: 42, name: "again some name for funding"}
+    ],
+    step_templates: [
+      %{description: "some description", name: "some name", rank: 42},
+      %{description: "again some description", name: "again some name", rank: 42}
+    ]
+  }
+  @update_attrs %{description: "some updated description", name: "some updated name", unit: "some updated unit", days: 15, validate: 85,}
   @invalid_attrs %{description: nil, name: nil, unit: nil}
 
   def fixture(:funding) do
@@ -31,6 +40,14 @@ defmodule HomerWeb.Monetizations.FundingControllerTest do
 
       conn = get conn, monetizations_funding_path(conn, :show, id)
       response = json_response(conn, 200)["funding"]
+
+      value = length Map.get(response, "projects")
+      assert value == 0
+      value = length Map.get(response, "invests_allows")
+      assert value == 2
+      value = length Map.get(response, "step_templates")
+      assert value == 2
+
       assert response == %{
         "id" => id,
         "create" => "#{Ecto.DateTime.to_iso8601(Ecto.DateTime.utc)}.000000Z",
@@ -41,8 +58,9 @@ defmodule HomerWeb.Monetizations.FundingControllerTest do
         "days" => 10,
         "validate" => 80,
         "projects" => [],
-        "step_templates" => [],
-         "invests_allows" => []}
+        "step_templates" => Map.get(response, "step_templates"),
+        "invests_allows" => Map.get(response, "invests_allows")
+      }
     end
 
     test "renders errors when data is invalid", %{conn: conn} do
@@ -60,6 +78,14 @@ defmodule HomerWeb.Monetizations.FundingControllerTest do
 
       conn = get conn, monetizations_funding_path(conn, :show, id)
       response = json_response(conn, 200)["funding"]
+
+      value = length Map.get(response, "projects")
+      assert value == 0
+      value = length Map.get(response, "invests_allows")
+      assert value == 2
+      value = length Map.get(response, "step_templates")
+      assert value == 2
+
       assert response == %{
         "id" => id,
         "create" => "#{Ecto.DateTime.to_iso8601(create)}.000000Z",
@@ -70,8 +96,9 @@ defmodule HomerWeb.Monetizations.FundingControllerTest do
         "days" => 15,
         "validate" => 85,
         "projects" => [],
-        "step_templates" => [],
-        "invests_allows" => []}
+        "step_templates" => Map.get(response, "step_templates"),
+        "invests_allows" => Map.get(response, "invests_allows")
+      }
     end
 
     test "renders errors when data is invalid", %{conn: conn, funding: funding} do


### PR DESCRIPTION
Add all reference on constructor. Create elements in constructor if need, ex: project.
Security/perfomance: If a project is create with bad data for steps, it will flush in db and after delete element. Is not perfect but it work and it easier. -> To update when possible.
Rectoring: Code are refactoring in part during coding. Refactoring is again possible I think.
